### PR TITLE
Fix conversion of tile coordinates

### DIFF
--- a/write_geometry.go
+++ b/write_geometry.go
@@ -1,12 +1,13 @@
 package vt
 
 import (
-	m "github.com/murphy214/mercantile"
 	"math"
-	//pc "github.com/murphy214/polyclip"
+
+	m "github.com/murphy214/mercantile"
+	// pc "github.com/murphy214/polyclip"
 )
 
-const mercatorPole = 20037508.34
+const mercatorPole = math.Pi * 6378137 // radius at the equator
 
 type Cursor struct {
 	Geometry   []uint32
@@ -32,6 +33,7 @@ func TrimPolygonFloat(lines [][][]float64) [][][]float64 {
 	}
 	return lines
 }
+
 func TrimPolygon(lines [][][]int32) [][][]int32 {
 	for pos, line := range lines {
 		f, l := line[0], line[len(line)-1]
@@ -148,10 +150,10 @@ func (cur *Cursor) MakeLineFloat(coords [][]float64) {
 	for _, point := range coords[1:] {
 		cur.LinePoint(cur.SinglePoint(point))
 	}
-	//fmt.Println(lineTo(cur.Count), coords, cur.Count, len(coords), cur.Geometry)
+	// fmt.Println(lineTo(cur.Count), coords, cur.Count, len(coords), cur.Geometry)
 	cur.Geometry[startpos+3] = lineTo(cur.Count)
 
-	//return cur.Geometry
+	// return cur.Geometry
 
 }
 
@@ -195,7 +197,6 @@ func assert_winding_order(coord [][]int32, exp_orient string) [][]int32 {
 		return coord
 	}
 	return coord
-
 }
 
 // asserts a winding order
@@ -205,7 +206,7 @@ func (cur *Cursor) AssertConvert(coord [][]float64, exp_orient string) {
 	weight := 0.0
 	var oldpt []int32
 	newlist := make([][]int32, len(coord))
-	//newlist := [][]int32{firstpt}
+	// newlist := [][]int32{firstpt}
 	newlist[0] = firstpt
 	// iterating through each float point
 	for pos, floatpt := range coord[1:] {
@@ -237,7 +238,6 @@ func (cur *Cursor) AssertConvert(coord [][]float64, exp_orient string) {
 	newgeom = append(newgeom, closePath(1))
 	cur.Geometry = append(cur.Geometry, newgeom...)
 	cur.LastPoint = newlist[len(newlist)-1]
-
 }
 
 // makes a polygon
@@ -248,7 +248,7 @@ func (cur *Cursor) MakePolygon(coords [][][]int32) []uint32 {
 	coord := coords[0]
 	coord = assert_winding_order(coord, "clockwise")
 	cur.MakeLine(coord)
-	//cur.Geometry = append(cur.Geometry, cur.Geometry...)
+	// cur.Geometry = append(cur.Geometry, cur.Geometry...)
 	cur.Geometry = append(cur.Geometry, closePath(1))
 	// if multiple rings exist proceed to add those also
 	if len(coords) > 1 {
@@ -276,10 +276,9 @@ func (cur *Cursor) MakePolygonFloat(coords [][][]float64) {
 	if len(coords) > 1 {
 		for _, coord := range coords[1:] {
 			cur.AssertConvert(coord, "counter")
-
 		}
 	}
-	//return cur.Geometry
+	// return cur.Geometry
 }
 
 // converts a single point from a coordinate to a tile point
@@ -330,7 +329,6 @@ func (cur *Cursor) MakePointFloat(point []float64) {
 	coords := []int32{newpoint[0], newpoint[1]}
 	cur.Geometry = []uint32{moveTo(uint32(1))}
 	cur.LinePoint(coords)
-
 }
 
 func (cur *Cursor) MakePoint(point []int32) {
@@ -366,14 +364,14 @@ func (cur *Cursor) MakeMultiLine(lines [][][]int32) {
 }
 
 func (cur *Cursor) MakeMultiPolygonFloat(lines [][][][]float64) {
-	//lines = TrimMultiPolygonFloat(lines)
+	// lines = TrimMultiPolygonFloat(lines)
 	for _, line := range lines {
 		cur.MakePolygonFloat(line)
 	}
 }
 
 func (cur *Cursor) MakeMultiPolygon(lines [][][][]int32) {
-	//lines = TrimMultiPolygon(lines)
+	// lines = TrimMultiPolygon(lines)
 
 	for _, line := range lines {
 		cur.MakePolygon(line)

--- a/write_geometry.go
+++ b/write_geometry.go
@@ -154,7 +154,6 @@ func (cur *Cursor) MakeLineFloat(coords [][]float64) {
 	cur.Geometry[startpos+3] = lineTo(cur.Count)
 
 	// return cur.Geometry
-
 }
 
 // reverses the coord list
@@ -283,42 +282,15 @@ func (cur *Cursor) MakePolygonFloat(coords [][][]float64) {
 
 // converts a single point from a coordinate to a tile point
 func (cur *Cursor) SinglePoint(point []float64) []int32 {
-	if cur.Bounds.N < point[1] {
-		cur.Bounds.N = point[1]
-	} else if cur.Bounds.S > point[1] {
-		cur.Bounds.S = point[1]
-	}
-	if cur.Bounds.E < point[0] {
-		cur.Bounds.E = point[0]
-	} else if cur.Bounds.W > point[0] {
-		cur.Bounds.W = point[0]
-	}
 	// converting to sperical coordinates
 	point = ConvertPoint(point)
 
-	// getting factors to multiply by
+	// getting factors to multiply by (0 <= factor <= 1)
 	factorx := (point[0] - cur.Bounds.W) / cur.DeltaX
 	factory := (cur.Bounds.N - point[1]) / cur.DeltaY
 
 	xval := int32(factorx * float64(cur.Extent))
 	yval := int32(factory * float64(cur.Extent))
-
-	if cur.ExtentBool {
-		if xval >= cur.Extent {
-			xval = cur.Extent
-		}
-
-		if yval >= cur.Extent {
-			yval = cur.Extent
-		}
-
-		if xval < 0 {
-			xval = 0
-		}
-		if yval < 0 {
-			yval = 0
-		}
-	}
 
 	return []int32{xval, yval}
 }

--- a/write_geometry.go
+++ b/write_geometry.go
@@ -292,6 +292,25 @@ func (cur *Cursor) SinglePoint(point []float64) []int32 {
 	xval := int32(factorx * float64(cur.Extent))
 	yval := int32(factory * float64(cur.Extent))
 
+	// this code ensures if your configuration is specified  
+	// that a single point will not be outside the extent of a tile 
+	if cur.ExtentBool {
+		if xval >= cur.Extent {
+			xval = cur.Extent
+		}
+
+		if yval >= cur.Extent {
+			yval = cur.Extent
+		}
+
+		if xval < 0 {
+			xval = 0
+		}
+		if yval < 0 {
+			yval = 0
+		}
+	}
+
 	return []int32{xval, yval}
 }
 

--- a/write_layer.go
+++ b/write_layer.go
@@ -32,7 +32,7 @@ type Config struct {
 	Extent     int32    // extent will assume 4096 if 0
 	Version    int      // version number will assume 15 if 0
 	ReduceBool bool
-	ExtentBool bool
+	ExtentBool bool 	// the extent bool that determines if all points should fall within the tile bound
 }
 
 // creates a new layer


### PR DESCRIPTION
When converting a feature to a vector tile, I noticed that at lower zoom levels the x-value almost always was 4096 (the tile extent). This was caused by a `factorx` greater than 1. I assume this value should stay between 0 and 1. What makes some of the code unnecessary. I ran some test in all four quadrants without issues.

Further I improved the accuracy of the pole bound by calculating it with the radius at the equator.